### PR TITLE
Download recipe code should not fail when the recipe URL is empty

### DIFF
--- a/backend/services/DownloadService.js
+++ b/backend/services/DownloadService.js
@@ -15,7 +15,9 @@ exports.downloadRecipe = function (options, callback) {
         }
 
         if (!cloudifyRecipeUrl) {
-            throw new Error('Cloudify Recipe url parameter is missing');
+//            throw new Error('Cloudify Recipe url parameter is missing');
+            logger.info('Cloudify Recipe url parameter is missing, nothing to download');
+            callback(null);
         }
 
         logger.debug('making destination dir [' + destDir + ']');


### PR DESCRIPTION
it should instead continue the bootstrap process, under the assumption that the user doens't want to run any recipe.
