### PR TITLE
improve(node status): add 'download pem' and 'pool error' better format

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -23,6 +23,7 @@
     "angular": false,
       "confirm":false,
       "$":false,
-      "toastr":false
+      "toastr":false,
+      "_" : false
   }
 }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -89,7 +89,7 @@ module.exports = function (grunt) {
                 {
                     context: '/backend',
                     host: '127.0.0.1',
-                    port: 9001,
+                    port: 9003,
                     https: false,
                     changeOrigin: false,
                     xforward: false
@@ -449,7 +449,8 @@ module.exports = function (grunt) {
             },
             debug:{
                 configFile: 'karma.conf.js',
-                singleRun: false
+                singleRun: false,
+                autoWatch:true
             },
             single: {
                 configFile: 'karma.conf.js',

--- a/app/index.html
+++ b/app/index.html
@@ -64,8 +64,8 @@
         <script src="bower_components/gs-ui-infra/app/scripts/filters/i18n.js"></script>
         <script src="bower_components/gs-ui-infra/app/scripts/services/i18next.js"></script>
         <script src="bower_components/angular-bootstrap/ui-bootstrap-tpls.js"></script>
-        <script src="bower_components/lodash/dist/lodash.js"></script>
-        <script src="bower_components/angular-lodash/angular-lodash.js"></script>
+        <script src="bower_components/underscore/underscore.js"></script>
+        <script src="bower_components/angular-underscore/angular-underscore.js"></script>
         <script src="scripts/constants/WidgetConstants.js"></script>
         <script src="scripts/controllers/Login.js"></script>
         <script src="scripts/controllers/Demo.js"></script>
@@ -112,11 +112,10 @@
       <script src="scripts/controllers/admin/PoolView.js"></script>
       <script src="scripts/controllers/admin/PoolUpdate.js"></script>
       <script src="scripts/controllers/admin/WidgetRead.js"></script>
-      <script src="scripts/controllers/documentation/index.js"></script>
-      <script src="scripts/controllers/documentation/FrontendApi.js"></script>
       <script src="scripts/directives/blankFrame.js"></script>
-      <script src="scripts/directives/plunkr.js"></script>
-      <script src="scripts/directives/snippet.js"></script>
+
+      <script src="scripts/directives/poolerror.js"></script>
+      <script src="scripts/directives/downloadpem.js"></script>
       <!-- endbuild -->
 
     <!-- on purpose, taking this file out, making it debuggable on environments -->

--- a/app/scripts/directives/downloadpem.js
+++ b/app/scripts/directives/downloadpem.js
@@ -1,0 +1,37 @@
+'use strict';
+
+/**
+ * @ngdoc directive
+ * @name cloudifyWidgetUiApp.directive:downloadPem
+ * @description
+ * # downloadPem
+ */
+angular.module('cloudifyWidgetUiApp')
+    .directive('downloadPem', function ( ) {
+        return {
+            template: '<button class="btn btn-link" ng-show="hasPem()" ng-click="downloadPem()">download pem</button><button class="btn btn-link" ng-show="hasPem()" ng-click="showPem()">show pem</button><pre class="pem-content" ng-show="shouldShowPem">{{sshDetails.privateKey}}</pre>',
+            restrict: 'A',
+            scope: {
+                'sshDetails': '=downloadPem'
+            },
+            link: function postLink(scope) {
+
+                scope.shouldShowPem = false;
+
+                scope.hasPem = function () {
+                    return !!scope.sshDetails && !!scope.sshDetails.privateKey;
+                };
+
+                scope.showPem = function () {
+                    scope.shouldShowPem = !scope.shouldShowPem;
+                };
+
+                scope.downloadPem = function () {
+                    var pom = document.createElement('a');
+                    pom.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(scope.sshDetails.privateKey));
+                    pom.setAttribute('download', 'pem.txt');
+                    pom.click();
+                };
+            }
+        };
+    });

--- a/app/scripts/directives/poolerror.js
+++ b/app/scripts/directives/poolerror.js
@@ -1,0 +1,50 @@
+'use strict';
+
+/**
+ * @ngdoc directive
+ * @name cloudifyWidgetUiApp.directive:poolError
+ * @description
+ * # poolError
+ */
+angular.module('cloudifyWidgetUiApp')
+    .directive('poolError', function ($log) {
+        return {
+            template: ' <pre>{{ data }}</pre>',
+            restrict: 'A',
+            scope: {
+                'dataObj': '=poolError'
+            },
+            link: function postLink(scope) {
+                scope.$watch('dataObj', function (newValue, oldValue) {
+                    $log.info('poolerror changed', newValue, oldValue);
+                    if (!!newValue) {
+
+                        var infoObj = newValue.info;
+                        try {
+                            infoObj = JSON.parse(infoObj);
+                        } catch (e) {
+
+                        }
+
+                        if (infoObj.hasOwnProperty('stackTrace')) {
+                            if (typeof(infoObj.stackTrace ) === 'string') {
+                                infoObj = infoObj.stackTrace;
+                            } else { // object
+                                try {
+                                    infoObj = _.map(infoObj.stackTrace, function (item) {
+                                        return item.className + '#' + item.methodName + ' [' + item.fileName + '] ' + item.lineNumber;
+                                    });
+                                    infoObj = infoObj.join('\n');
+                                } catch (e) {
+
+                                }
+                            }
+
+                        }
+                        scope.data = infoObj;
+                    }
+                });
+
+            }
+        };
+    });

--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -12,7 +12,9 @@
   padding: 2px;
 }
 
+
 // ------------------------------------------------
+
 
 // hide multiple layouts layers for "logged-in-layout" - means that if I have 2 pages one within another with the layout, the other layout will be hidden.
 #logged-in-layout {
@@ -223,4 +225,9 @@
 #documentation .plunkr-link:active {
   position: relative;
   top: 1px;
+}
+
+[pool-error] pre{
+  font-size:10px;
+  width:800px;
 }

--- a/app/views/admin/poolErrors.html
+++ b/app/views/admin/poolErrors.html
@@ -15,14 +15,16 @@
             </tr>
         </thead>
         <tbody>
-            <tr ng-repeat="error in model.poolErrors">
+            <tr ng-repeat="error in model.poolErrors track by $index">
                 <td>{{ error.id }}</td>
                 <!--<td>{{ error.timestamp | date:'medium' }}</td>--> <!-- this causes problems for some reason -->
                 <td>{{ error.timestamp }}</td>
                 <td>{{ error.source }}</td>
                 <td>{{ error.poolId }}</td>
                 <td><pre>{{ error.message }}</pre></td>
-                <td><pre>{{ asJson(error.info) | json }}</pre></td>
+                <td>
+                    <div pool-error="error"></div>
+                </td>
             </tr>
         </tbody>
     </table>

--- a/app/views/admin/poolNodes.html
+++ b/app/views/admin/poolNodes.html
@@ -21,7 +21,7 @@
                 <td>{{ node.machineId }}</td>
                 <td>{{ node.poolId }}</td>
                 <td>{{ node.nodeStatus }}</td>
-                <td><pre>{{ asJson(node.machineSshDetails) | json }}</pre></td>
+                <td><div download-pem="node.machineSshDetails"></div><pre>{{ asJson(node.machineSshDetails) | json }}</pre></td>
                 <td>{{ node.expires | date:"medium" }} </td>
                 <td>
                     <button ng-if="node.id" ng-click="pingNode(model.poolId, node.id)">ping</button><br>

--- a/backend/managers/PoolRestClient.js
+++ b/backend/managers/PoolRestClient.js
@@ -136,12 +136,14 @@ function Call() {
     }
 
     this.invoke = function (method, url, args, callback) {
+
         var myArgs = args;
         if (args instanceof ArgsBuilder) {
             myArgs = args.done();
         }
         logger.info('POST: ', url);
         var myUrl = _url(url);
+        logger.debug(myArgs);
         var myCallback = _callbackWrapper(callback);
         try {
             var req;

--- a/test.jshintrc
+++ b/test.jshintrc
@@ -25,6 +25,8 @@
         "inject":false,
         "beforeEach":false,
         "describe":false,
-        "angular":false
+        "angular":false,
+        "spyOn" : false,
+        "$": false
     }
 }

--- a/test/spec/directives/downloadpem.js
+++ b/test/spec/directives/downloadpem.js
@@ -1,0 +1,59 @@
+'use strict';
+
+describe('Directive: downloadPem', function () {
+
+    // load the directive's module
+    beforeEach(module('cloudifyWidgetUiApp'));
+
+    var element,
+        isolateScope,
+        scope;
+
+    beforeEach(inject(function ($rootScope) {
+        scope = $rootScope.$new();
+    }));
+
+    var setup = inject(function($compile){
+        element = angular.element('<div download-pem="sshDetails"></div>');
+        element = $compile(element)(scope);
+        isolateScope = element.children().scope();
+        scope.$digest();
+
+    });
+
+    it('should make hidden element visible', function () {
+        setup();
+        expect(element.text().indexOf('download pem') >= 0).toBe(true);
+    });
+
+    it('change value of shouldShowPem when showPem is called', function(){
+        setup();
+        expect(isolateScope.shouldShowPem).toBe(false);
+        isolateScope.showPem();
+        expect(isolateScope.shouldShowPem).toBe(true);
+        isolateScope.showPem();
+        expect(isolateScope.shouldShowPem).toBe(false);
+
+    });
+
+    it('should detect is has a pem', function(){
+        setup();
+
+        expect(isolateScope.hasPem()).toBe(false);
+        isolateScope.sshDetails = {};
+        expect(isolateScope.hasPem()).toBe(false);
+        isolateScope.sshDetails = { privateKey : 'this is private key' };
+        expect(isolateScope.hasPem()).toBe(true);
+    });
+
+    it('should create an anchor tag and download file', inject(function( ){
+        setup();
+        isolateScope.sshDetails = { 'privateKey' : 'this is private key' };
+        spyOn(document, 'createElement').andCallThrough();
+        $('body').append(element);
+        isolateScope.downloadPem();
+        expect(document.createElement).toHaveBeenCalledWith('a');
+    }));
+
+
+});

--- a/test/spec/directives/poolerror.js
+++ b/test/spec/directives/poolerror.js
@@ -1,0 +1,55 @@
+'use strict';
+
+describe('Directive: poolError', function () {
+
+    // load the directive's module
+    beforeEach(module('cloudifyWidgetUiApp'));
+
+    var element,
+        isolateScope,
+        scope;
+
+    beforeEach(inject(function ($rootScope) {
+        scope = $rootScope.$new();
+    }));
+
+    var setup = inject(function ($compile) {
+        element = angular.element('<div pool-error="data"></div>');
+        element = $compile(element)(scope);
+        scope.$digest();
+        isolateScope = element.children().scope();
+    });
+
+    var flushAll = inject(function ($timeout) {
+        try {
+            $timeout.flush();
+        }catch(e){}
+        try {
+            scope.$digest();
+        }catch(e){}
+    });
+
+    it('put data on scope', inject(function () {
+        scope.poolError = {};
+        setup();
+
+
+        isolateScope.dataObj = { 'info' : 'this is stack trace' } ;
+        flushAll();
+
+        expect(isolateScope.data).toBe('this is stack trace');
+
+        isolateScope.dataObj = { 'info' : { 'stackTrace' : 'has stackTrace' }  };
+        flushAll();
+        expect(isolateScope.data).toBe('has stackTrace');
+
+
+        // item.className + '#' + item.methodName + ' [' + item.fileName + '] ' + item.lineNumber;
+        isolateScope.dataObj = { 'info' : { 'stackTrace' : [ { 'className' : 'a', 'methodName' : 'b' , 'fileName' : 'c', 'lineNumber' : '1'}, { 'className' : 'a1', 'methodName' : 'b1' , 'fileName' : 'c1', 'lineNumber' : '2'} ] }  };
+        flushAll();
+        expect(isolateScope.data).toBe('a#b [c] 1\na1#b1 [c1] 2');
+
+
+
+    }));
+});


### PR DESCRIPTION
A few things that really bothered me in the UI.. 

The "pem file" - I added a link to download it, and a link to "display" it without \n characters.. easier for copy/paste. 

The "error", I made it support in different formats - some are for backward compatibility and some for future formats (see modules pull request). 
